### PR TITLE
bug: Second declaration of 'value'

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -567,7 +567,7 @@ const Path = new Lang.Class({
             menu.actor.visible = visible;
         }
 
-        let value = this.getDisplaySystem();
+        value = this.getDisplaySystem();
         for (let key in this.system) {
             if (key === 'header')
                 continue;


### PR DESCRIPTION
Removes the second declaration for `value` which prevents the installation of the plugin on GNOME 3.26.1

Solves issue #4 